### PR TITLE
Add initial personal portfolio site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # henryeckersley.github.io
-my personal website or portfolio
+
+This repository hosts Henry Eckersley's personal website and portfolio.
+It is a simple static site powered by HTML, CSS and JavaScript. The site
+can be viewed via GitHub Pages at `https://henryeckersley.github.io` once
+the repository is published.
+
+## Development
+
+No build step is required. Simply edit the HTML, CSS and JavaScript files
+and push the changes. GitHub Pages will automatically serve the updated
+site.
+
+## Features
+
+- Responsive layout with a hero header
+- Portfolio section with example projects
+- Dark mode toggle implemented with vanilla JS
+
+Feel free to customize the content and design to showcase your own work!

--- a/index.html
+++ b/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Henry Eckersley - Portfolio</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header class="hero">
+        <h1>Henry Eckersley</h1>
+        <p>Developer & Designer</p>
+        <nav>
+            <a href="#about">About</a>
+            <a href="#portfolio">Portfolio</a>
+            <a href="#contact">Contact</a>
+            <button id="mode-toggle" aria-label="toggle dark mode">Dark Mode</button>
+        </nav>
+    </header>
+    <main>
+        <section id="about">
+            <h2>About Me</h2>
+            <p>Welcome to my personal website! I am Henry Eckersley, a web developer with a passion for clean design and interactive experiences. Here you can learn more about my projects and get in touch.</p>
+        </section>
+        <section id="portfolio">
+            <h2>Portfolio</h2>
+            <div class="portfolio-grid">
+                <div class="portfolio-item"><img src="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=800&q=60" alt="Project 1"><p>Project One</p></div>
+                <div class="portfolio-item"><img src="https://images.unsplash.com/photo-1517694712202-14dd9538aa97?auto=format&fit=crop&w=800&q=60" alt="Project 2"><p>Project Two</p></div>
+                <div class="portfolio-item"><img src="https://images.unsplash.com/photo-1508780709619-79562169bc64?auto=format&fit=crop&w=800&q=60" alt="Project 3"><p>Project Three</p></div>
+            </div>
+        </section>
+        <section id="contact">
+            <h2>Contact</h2>
+            <p>Feel free to reach out to me via <a href="mailto:henry@example.com">email</a> or find me on <a href="https://github.com/henryeckersley">GitHub</a>.</p>
+        </section>
+    </main>
+    <footer>
+        <p>&copy; 2024 Henry Eckersley. All rights reserved.</p>
+    </footer>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,4 @@
+document.getElementById('mode-toggle').addEventListener('click', function() {
+  document.body.classList.toggle('dark-mode');
+  this.textContent = document.body.classList.contains('dark-mode') ? 'Light Mode' : 'Dark Mode';
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,78 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+body {
+  font-family: Arial, Helvetica, sans-serif;
+  line-height: 1.6;
+  background-color: #f4f4f4;
+  color: #333;
+}
+header.hero {
+  background: url('https://images.unsplash.com/photo-1503264116251-35a269479413?auto=format&fit=crop&w=1050&q=80') center/cover no-repeat;
+  color: white;
+  text-align: center;
+  padding: 4rem 1rem;
+}
+header.hero h1 {
+  font-size: 3rem;
+  margin-bottom: 0.5rem;
+}
+header.hero nav {
+  margin-top: 1rem;
+}
+header.hero nav a {
+  color: white;
+  margin: 0 0.5rem;
+  text-decoration: none;
+  font-weight: bold;
+}
+#mode-toggle {
+  margin-left: 1rem;
+  padding: 0.3rem 0.6rem;
+  background: rgba(255, 255, 255, 0.2);
+  border: 2px solid white;
+  color: white;
+  cursor: pointer;
+  border-radius: 4px;
+}
+main {
+  max-width: 900px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+}
+section {
+  margin-bottom: 2rem;
+}
+.portfolio-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  grid-gap: 1rem;
+}
+.portfolio-item {
+  background: white;
+  border-radius: 5px;
+  overflow: hidden;
+  box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+}
+.portfolio-item img {
+  width: 100%;
+  display: block;
+}
+footer {
+  text-align: center;
+  padding: 1rem 0;
+  background: #333;
+  color: #fff;
+}
+.dark-mode {
+  background-color: #222;
+  color: #f4f4f4;
+}
+.dark-mode header.hero {
+  background-blend-mode: multiply;
+}
+.dark-mode header.hero nav a {
+  color: #f4f4f4;
+}


### PR DESCRIPTION
## Summary
- set up index.html with hero, about, portfolio and contact sections
- add CSS styling and dark mode support
- include simple JS to toggle dark mode
- document repo purpose and development notes in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687be724979083279256e3054cf5bb30